### PR TITLE
add cosponsor_ids to es_only bill fields

### DIFF
--- a/tasks/bills_text/bills_text.rb
+++ b/tasks/bills_text/bills_text.rb
@@ -42,6 +42,7 @@ class BillsText
       # ES will index a bill's basic fields plus these others
       es_only = Utils.bill_for(bill).merge(
         sponsor: bill['sponsor'],
+        cosponsor_ids: bill['cosponsor_ids'],
         last_action: bill['last_action'],
         summary: bill['summary'],
         summary_short: bill['summary_short'],


### PR DESCRIPTION
[According to](https://groups.google.com/d/msg/sunlightlabs-api-discuss/lQqmCm_Oa4s/uPY4ta9dA_gJ) @konklone, this is all that is needed to make *cosponsor_ids* a selectable field when using the bill search endpoint.