### PR TITLE
correct date format in docs example

### DIFF
--- a/votes.md
+++ b/votes.md
@@ -47,7 +47,7 @@ Search and filter through votes in Congress. Filter by any [fields below](#field
 **Votes since July 2, 2013**
 
 {% highlight text %}
-/votes?voted_at__gte=2013-07-02T4:00:00Z
+/votes?voted_at__gte=2013-07-02T04:00:00Z
 {% endhighlight %}
 
 ## Fields


### PR DESCRIPTION
the example in the docs is missing a digit and does not work.